### PR TITLE
Implement Level of Detail system (LOD)

### DIFF
--- a/.github/workflows/ci-appimage.yml
+++ b/.github/workflows/ci-appimage.yml
@@ -9,7 +9,7 @@ on:
     types: [published]
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout source

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,9 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(BUILD_APPIMAGE "Enable AppImage packaging" OFF)
+set(MAXLOGLEVEL 5 CACHE STRING "Set maximum log level")
 
-# Define application-specific compile definitions
-option(MAXLOGLEVEL "Set maximum log level" 5)
 add_compile_definitions(MAXLOGLEVEL=${MAXLOGLEVEL})
-
 add_compile_definitions(USEFONT=UbuntuMono-Regular.ttf)
 include(CMakeRC)
 file(GLOB_RECURSE RESOURCES RELATIVE ${CMAKE_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/resources/UbuntuMono-Regular.ttf")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 option(BUILD_APPIMAGE "Enable AppImage packaging" OFF)
 
 # Define application-specific compile definitions
-set(MAXLOGLEVEL 5)
+option(MAXLOGLEVEL "Set maximum log level" 5)
 add_compile_definitions(MAXLOGLEVEL=${MAXLOGLEVEL})
 
 add_compile_definitions(USEFONT=UbuntuMono-Regular.ttf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ set(SOURCES
   src/App.cpp
   src/MovieRecorder.cpp
   src/RParticleRenderer.cpp
+  src/LOD.cpp
   src/RWindow.cpp
   src/Camera.cpp
   src/RBox.cpp
@@ -61,6 +62,8 @@ set(SOURCES
   src/RRenderer.cpp
   src/math_helper.cpp
   src/RGL.cpp
+  src/RShaderProgram.cpp
+  src/icosphere.cpp
   src/RTextRenderer.cpp
   src/System.cpp)
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -112,15 +112,14 @@ void App::handle_events() {
       IF_KEY(c, this->screenshot();)
       IF_KEY(l, record_movie = !record_movie; play = !play;
              if (!record_movie) movieStop();)
-
       IF_KEY(4, gl->rotate_model(0.1f, 1, 0, 0);)
       IF_KEY(5, gl->rotate_model(0.1f, 0, 1, 0);)
       IF_KEY(6, gl->rotate_model(0.1f, 0, 0, 1);)
       IF_KEY(1, gl->rotate_model(-0.1f, 1, 0, 0);)
       IF_KEY(2, gl->rotate_model(-0.1f, 0, 1, 0);)
       IF_KEY(3, gl->rotate_model(-0.1f, 0, 0, 1);)
-      IF_KEY(0, cam->reset_camera_view(); gl->reset_model();
-             cam->warp(initial_camera_position);)
+      IF_KEY(0, gl->reset_model(); cam->warp(initial_camera_position);
+             cam->lookAt(initial_camera_center);)
     }
     if (e.type == SDL_WINDOWEVENT) {
       switch (e.window.event) {
@@ -160,6 +159,7 @@ void App::handle_events() {
             sqrt(rij[0] * rij[0] + rij[1] * rij[1] + rij[2] * rij[2]));
       }
     }
+    cam->handle_event(e);
   }
 }
 

--- a/src/App.h
+++ b/src/App.h
@@ -45,7 +45,7 @@ private:
   bool visible;
   bool play = false;
   bool record_movie = false;
-  glm::vec3 initial_camera_position;
+  glm::vec3 initial_camera_position, initial_camera_center;
 };
 } // namespace superpunto
 #endif

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -1,4 +1,5 @@
 #include "Camera.h"
+#include "System.h"
 #include <SDL2/SDL.h>
 
 namespace superpunto {
@@ -45,9 +46,19 @@ glm::mat4 FreeCamera::lookAt(glm::vec3 target) {
 
 #define KEYSTATE(KEY) keystate[SDL_SCANCODE_##KEY]
 
-void FreeCamera::update() {
-  const Uint8 *keystate = SDL_GetKeyboardState(NULL);
+void FreeCamera::handle_event(SDL_Event &e) {
+  if (e.type == SDL_TEXTINPUT) {
+    const char *txt = e.text.text;
+    if (txt[0] == '+' && txt[1] == '\0') {
+      this->mult *= 1.05f;
+    } else if (txt[0] == '-' && txt[1] == '\0') {
+      this->mult *= 0.95f;
+    }
+  }
+}
 
+void FreeCamera::update() {
+    const Uint8 *keystate = SDL_GetKeyboardState(NULL);
   if (KEYSTATE(A))
     this->pos += this->right * cspeed * mult;
   if (KEYSTATE(D))
@@ -60,21 +71,17 @@ void FreeCamera::update() {
     this->pos += this->up * cspeed * mult;
   if (KEYSTATE(LCTRL))
     this->pos -= this->up * cspeed * mult;
-  if (KEYSTATE(KP_PLUS))
-    this->mult *= 1.05;
-  if (KEYSTATE(KP_MINUS))
-    this->mult *= 0.95;
-
   if (KEYSTATE(E))
     this->roll = 4 * cspeed;
   if (KEYSTATE(Q))
     this->roll = -4 * cspeed;
-
   if (KEYSTATE(P)) {
-    printf("up: %.3f, %.3f, %.3f  \n", up.x, up.y, up.z);
-    printf("right: %.3f, %.3f, %.3f  \n", right.x, right.y, right.z);
-    printf("pos: %.3f, %.3f, %.3f  \n", pos.x, pos.y, pos.z);
-    printf("front: %.3f, %.3f, %.3f  \n\n", front.x, front.y, front.z);
+    System::log<System::MESSAGE>("up: %.3f, %.3f, %.3f", up.x, up.y, up.z);
+    System::log<System::MESSAGE>("right: %.3f, %.3f, %.3f", right.x, right.y,
+                                 right.z);
+    System::log<System::MESSAGE>("pos: %.3f, %.3f, %.3f", pos.x, pos.y, pos.z);
+    System::log<System::MESSAGE>("front: %.3f, %.3f, %.3f", front.x, front.y,
+                                 front.z);
   }
   if (KEYSTATE(LALT))
     process_mouse();

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -29,7 +29,20 @@ void FreeCamera::warp(glm::vec3 np) { this->pos = np; }
 glm::vec3 FreeCamera::get_view() { return pos + front; }
 
 glm::mat4 FreeCamera::lookAt() {
+  // Recompute right and up based on the default world up
   return this->view = glm::lookAt(pos, pos + front, up);
+}
+
+glm::mat4 FreeCamera::lookAt(glm::vec3 target) {
+  // Compute the new front direction toward the target
+  this->front = glm::normalize(target - this->pos);
+  // Use a fixed "world up" vector (Z-up) to compute a new basis
+  glm::vec3 worldUp = glm::vec3(0.0f, 0.0f, 1.0f);
+  // Recompute right and up so that front faces the target
+  this->right = glm::normalize(glm::cross(worldUp, this->front));
+  this->up = glm::normalize(glm::cross(this->front, this->right));
+  yaw = pitch = roll = 0;
+  return this->lookAt();
 }
 
 #define KEYSTATE(KEY) keystate[SDL_SCANCODE_##KEY]

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -26,8 +26,6 @@ void FreeCamera::reset_camera_view() {
 }
 void FreeCamera::warp(glm::vec3 np) { this->pos = np; }
 
-glm::vec3 FreeCamera::get_view() { return pos + front; }
-
 glm::mat4 FreeCamera::lookAt() {
   // Recompute right and up based on the default world up
   return this->view = glm::lookAt(pos, pos + front, up);

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -16,6 +16,7 @@ public:
   void warp(glm::vec3 np);
   glm::vec3 get_view();
   glm::mat4 lookAt();
+  glm::mat4 lookAt(glm::vec3 target);
 
   void reset_camera_view();
 

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -14,7 +14,6 @@ public:
   FreeCamera();
 
   void warp(glm::vec3 np);
-  glm::vec3 get_view();
   glm::mat4 lookAt();
   glm::mat4 lookAt(glm::vec3 target);
 

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -7,7 +7,7 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtc/type_ptr.hpp>
-
+#include <SDL2/SDL.h>
 namespace superpunto {
 class FreeCamera {
 public:
@@ -20,6 +20,7 @@ public:
   void reset_camera_view();
 
   void update();
+  void handle_event(SDL_Event &e);
   void process_mouse();
   void updateCameraVectors();
   void set_origin();
@@ -29,6 +30,8 @@ public:
 
   glm::mat4 view;
   glm::vec3 pos, up, front, right;
+  glm::vec3 world_up = glm::vec3(0, 0, 1);
+
   float yaw, pitch, roll;
 
   float mult;

--- a/src/LOD.cpp
+++ b/src/LOD.cpp
@@ -1,0 +1,63 @@
+#include "LOD.h"
+#include "glm/gtc/type_ptr.hpp"
+#include "shaders.h"
+
+namespace superpunto {
+
+LODProgram::LODProgram(int num_lods, float min_dist, float max_dist,
+                       float gscale)
+    : num_lods(num_lods), max_particles(0), min_dist(min_dist),
+      max_dist(max_dist), counts(num_lods, 0), gscale(gscale) {
+  counter_buffer.init(GL_SHADER_STORAGE_BUFFER, GL_DYNAMIC_STORAGE_BIT);
+  counter_buffer.initmem(num_lods * sizeof(GLuint), nullptr);
+  RShader sh;
+  sh.charload(shaders_lod_cs, GL_COMPUTE_SHADER);
+  compute_shader.init(&sh, 1);
+}
+
+void LODProgram::sort(int num_particles, const glm::vec3 &cam_pos,
+                      const glm::mat4 &view, const glm::mat4 &model,
+                      const glm::mat4 &proj, const glm::int2 resolution,
+                      const VBO &pos_buffer) {
+  if (num_particles > max_particles) {
+    this->resize(num_particles);
+  }
+  compute_shader.use();
+  std::vector<GLuint> zero(num_lods, 0);
+  counter_buffer.upload(0, num_lods * sizeof(GLuint), zero.data());
+  glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, pos_buffer.id());
+  glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, index_buffer.id());
+  glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, counter_buffer.id());
+  compute_shader.setUniform<GLfloat>("lod_pixel_min", min_dist);
+  compute_shader.setUniform<GLfloat>("lod_pixel_max", max_dist);
+  compute_shader.setUniform<GLfloat>("gscale", gscale);
+  compute_shader.setUniform<GLint>("num_lods", num_lods);
+  compute_shader.setUniform<glm::ivec2>("screen_resolution", resolution);
+  const auto modelview = view * model;
+  compute_shader.setUniform<glm::mat4>("modelview", modelview);
+  compute_shader.setUniform<glm::mat4>("projection", proj);
+  glDispatchCompute((num_particles + 255) / 256, 1, 1);
+  glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT |
+                  GL_ATOMIC_COUNTER_BARRIER_BIT);
+  counter_buffer.use();
+  glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, num_lods * sizeof(GLuint),
+                     counts.data());
+  CheckGLError("Error in LODProgram::sort");
+}
+
+void LODProgram::resize(int new_max_particles) {
+  if (new_max_particles > max_particles) {
+    max_particles = new_max_particles;
+    index_buffer.reset();
+    index_buffer.init(GL_SHADER_STORAGE_BUFFER, GL_DYNAMIC_STORAGE_BIT);
+    index_buffer.initmem(num_lods * new_max_particles * sizeof(GLuint),
+                         nullptr);
+    compute_shader.setUniform<GLint>("lod_stride", max_particles);
+  }
+}
+
+const VBO &LODProgram::get_index_buffer() const { return index_buffer; }
+
+const std::vector<GLuint> &LODProgram::get_counts() const { return counts; }
+
+} // namespace superpunto

--- a/src/LOD.h
+++ b/src/LOD.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "RGL.h"
+#include <memory>
+#include <vector>
+
+namespace superpunto {
+
+class LODProgram {
+public:
+  LODProgram(int num_lods, float min_dist, float max_dist, float gscale);
+  void sort(int num_particles, const glm::vec3 &camera_pos,
+            const glm::mat4 &view, const glm::mat4 &model,
+            const glm::mat4 &proj, const glm::int2 resolution,
+            const VBO &pos_buffer);
+  void resize(int max_particles);
+  const VBO &get_index_buffer() const;
+  const std::vector<GLuint> &get_counts() const;
+  int get_lod_stride() const { return this->max_particles; }
+
+private:
+  int num_lods;
+  int max_particles;
+  float min_dist, max_dist, gscale;
+  VBO index_buffer;
+  VBO counter_buffer;
+  std::vector<GLuint> counts;
+  RShaderProgram compute_shader;
+};
+
+} // namespace superpunto

--- a/src/RBox.cpp
+++ b/src/RBox.cpp
@@ -12,8 +12,8 @@ namespace superpunto{
     dl.init(3, 3*sizeof(float), GL_FLOAT, 0);
     vbo.init(GL_ARRAY_BUFFER, GL_MAP_READ_BIT, dl);
     fill_box_vbo(vbo);
-  
-    vao.set_attrib(0, vbo, 0);//Attrib nº0 is in vbo and binded to 0 in shader
+
+    vao.set_attrib(0, vbo);
 
     RShader shs[2];
     shs[0].charload(shaders_box_vs, GL_VERTEX_SHADER);
@@ -44,7 +44,7 @@ namespace superpunto{
     glLineWidth(3.0f);
     glDrawArrays(GL_LINES, 0, 72);
     glLineWidth(1.0f);
-    vao.unbind();  
+    vao.unbind();
     pr.unbind();
   };
 
@@ -65,7 +65,7 @@ namespace superpunto{
     };
 
     fori(0,72) v[i] -= 0.5f;
-    
+
     boxVBO.initmem(sizeof(v), v);
   }
 }

--- a/src/RGL.cpp
+++ b/src/RGL.cpp
@@ -224,13 +224,8 @@ FBO::FBO(std::shared_ptr<System> sys, glm::int2 resolution)
   glCreateFramebuffers(1, &fid);
   sys->log<System::DEBUG>("Init FBO with id %d", fid);
   CheckGLError("Error at FBO creation");
-  // Rendering textures/buffers
-  // draw_buffer = new GLenum[2];
   draw_buffer[0] = GL_COLOR_ATTACHMENT0;
-  // Color  texture
-
   ctex.init(GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE, glm::vec2(fwidth, fheight));
-
   glNamedFramebufferTexture(fid, draw_buffer[0], ctex, 0);
   glNamedFramebufferDrawBuffers(fid, 1, draw_buffer.data());
   RShader shs[2];
@@ -247,9 +242,7 @@ void FBO::setFormat(GLenum ifmt, GLenum efmt, GLenum dtp) {
   CheckGLError("Error at setting format");
 }
 
-FBO::~FBO() {
-  glDeleteFramebuffers(1, &fid);
-}
+FBO::~FBO() { glDeleteFramebuffers(1, &fid); }
 
 void FBO::draw() {
   this->unbind();

--- a/src/RGL.cpp
+++ b/src/RGL.cpp
@@ -287,9 +287,6 @@ void FBO::handle_resize(int new_fwidth, int new_fheight) {
   CheckGLError("Error at FBO resize");
 }
 
-void FBO::bindColorTex(RShaderProgram &apr) {
-  apr.setFlag("ctex", ctex.getUnit());
-}
 
 GBuffer::~GBuffer() {}
 GBuffer::GBuffer(std::shared_ptr<System> sys, glm::int2 resolution)

--- a/src/RGL.cpp
+++ b/src/RGL.cpp
@@ -51,6 +51,31 @@ VBO::VBO() {
   CheckGLError("Error in init VBO");
 }
 VBO::~VBO() { glDeleteBuffers(1, &vid); }
+VBO::VBO(VBO &&other) noexcept {
+  vid = other.vid;
+  tp = other.tp;
+  flags = other.flags;
+  layout = other.layout;
+  initialized = other.initialized;
+  meminit = other.meminit;
+
+  other.vid = 0; // prevent deletion
+}
+
+VBO &VBO::operator=(VBO &&other) noexcept {
+  if (this != &other) {
+    glDeleteBuffers(1, &vid); // cleanup current
+    vid = other.vid;
+    tp = other.tp;
+    flags = other.flags;
+    layout = other.layout;
+    initialized = other.initialized;
+    meminit = other.meminit;
+    other.vid = 0;
+  }
+  return *this;
+}
+
 void VBO::reset() {
   if (vid)
     glDeleteBuffers(1, &vid);
@@ -116,6 +141,23 @@ VAO::VAO() {
 VAO::~VAO() { glDeleteVertexArrays(1, &vid); }
 
 void VAO::set_attrib(uint attrib, const VBO &vbo, GLint binding) {
+// Move constructor
+VAO::VAO(VAO &&other) noexcept {
+  vid = other.vid;
+  other.vid = 0;
+}
+
+// Move assignment
+VAO &VAO::operator=(VAO &&other) noexcept {
+  if (this != &other) {
+    if (vid)
+      glDeleteVertexArrays(1, &vid);
+    vid = other.vid;
+    other.vid = 0;
+  }
+  return *this;
+}
+
   if (vbo.type() == GL_ELEMENT_ARRAY_BUFFER)
     return;
   DataLayout dl = vbo.get_layout();

--- a/src/RGL.cpp
+++ b/src/RGL.cpp
@@ -206,7 +206,10 @@ bool RTex::upload(const void *data) {
   return true;
 }
 void RTex::resize(GLuint wx, GLuint wy) {
-  glDeleteTextures(1, &tid);
+  if (wx == size.x && wy == size.y)
+    return;
+  System::log<System::DEBUG>(
+      "[RTex] Texture %d resized to %d x %d", tid, wx, wy);
   init(format[0], format[1], format[2], glm::int2(wx, wy));
   CheckGLError("Error at texture resize");
 }

--- a/src/RGL.cpp
+++ b/src/RGL.cpp
@@ -249,15 +249,13 @@ void FBO::draw() {
   pr.use();
   vao.use();
   glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-  vao.unbind();
-  pr.unbind();
   CheckGLError("Error at fbo drawing");
 }
 
 void FBO::use() { glBindFramebuffer(tp, fid); }
 void FBO::unbind() { glBindFramebuffer(tp, 0); }
 
-glm::vec4 FBO::getPixel(int x, int y) {
+glm::u8vec4 FBO::getPixel(int x, int y) {
   // Origin equal to the one fiven by SDL mouse pos, not sure wich corner
   glBindFramebuffer(GL_READ_FRAMEBUFFER, fid);
   Uint8 p[4];

--- a/src/RGL.cpp
+++ b/src/RGL.cpp
@@ -140,7 +140,6 @@ VAO::VAO() {
 }
 VAO::~VAO() { glDeleteVertexArrays(1, &vid); }
 
-void VAO::set_attrib(uint attrib, const VBO &vbo, GLint binding) {
 // Move constructor
 VAO::VAO(VAO &&other) noexcept {
   vid = other.vid;
@@ -158,6 +157,7 @@ VAO &VAO::operator=(VAO &&other) noexcept {
   return *this;
 }
 
+void VAO::set_attrib(uint attrib, const VBO &vbo) {
   if (vbo.type() == GL_ELEMENT_ARRAY_BUFFER)
     return;
   DataLayout dl = vbo.get_layout();

--- a/src/RGL.cpp
+++ b/src/RGL.cpp
@@ -117,7 +117,7 @@ bool VBO::initmem(GLsizeiptr size, const void *data) {
   return true;
 }
 bool VBO::upload(GLenum type, GLintptr offset, GLsizeiptr size,
-                 const void *data) {
+                 const void *data) const {
   glBufferSubData(type, offset, size, data);
   return true;
 }
@@ -128,11 +128,11 @@ bool VBO::upload(GLintptr offset, GLsizeiptr size, const void *data) {
   return true;
 }
 
-void *VBO::map(GLenum usage) { return glMapNamedBuffer(vid, usage); }
-void VBO::unmap() { glUnmapNamedBuffer(vid); }
+void *VBO::map(GLenum usage) const{ return glMapNamedBuffer(vid, usage); }
+void VBO::unmap() const { glUnmapNamedBuffer(vid); }
 
-void VBO::use() { glBindBuffer(tp, vid); }
-void VBO::unbind() { glBindBuffer(tp, 0); }
+void VBO::use() const{ glBindBuffer(tp, vid); }
+void VBO::unbind() const { glBindBuffer(tp, 0); }
 
 VAO::VAO() {
   glCreateVertexArrays(1, &vid);

--- a/src/RGL.cpp
+++ b/src/RGL.cpp
@@ -1,5 +1,5 @@
 #include "RGL.h"
-#include<iostream>
+#include <iostream>
 
 namespace superpunto {
 const char *GetGLErrorStr(GLenum err) {

--- a/src/RGL.cpp
+++ b/src/RGL.cpp
@@ -302,12 +302,10 @@ GBuffer::GBuffer(std::shared_ptr<System> sys, glm::int2 resolution)
   glTextureParameteri(dtex, GL_TEXTURE_COMPARE_FUNC, GL_LEQUAL);
   glTextureParameteri(dtex, GL_TEXTURE_COMPARE_MODE, GL_NONE);
   glNamedFramebufferTexture(fid, GL_DEPTH_ATTACHMENT, dtex, 0);
-
   // Rendering textures/buffers
   draw_buffer[0] = GL_COLOR_ATTACHMENT0;
   draw_buffer[1] = GL_COLOR_ATTACHMENT1;
   draw_buffer[2] = GL_COLOR_ATTACHMENT2;
-
   // Normal and linear depth encoded as alpha, for SSAO
   normdtex.init(GL_RGBA32F, GL_RGBA, GL_FLOAT, resolution); // Color texture
   glNamedFramebufferTexture(fid, draw_buffer[1], normdtex, 0);
@@ -333,7 +331,6 @@ GBuffer::GBuffer(std::shared_ptr<System> sys, glm::int2 resolution)
     std::cerr << "[GBuffer] Framebuffer incomplete: 0x" << std::hex << status
               << std::endl;
   }
-
 }
 
 float *GBuffer::getDepthData() {

--- a/src/RGL.cpp
+++ b/src/RGL.cpp
@@ -162,12 +162,12 @@ void VAO::set_attrib(uint attrib, const VBO &vbo) {
     return;
   DataLayout dl = vbo.get_layout();
   this->use();
-  glBindBuffer(GL_ARRAY_BUFFER, vbo.id());
+  vbo.use();
   glEnableVertexAttribArray(attrib);
-  glVertexAttribPointer(attrib, dl.size, dl.type, dl.normalized, dl.stride, reinterpret_cast<void*>(static_cast<uintptr_t>(dl.offset)));
+  glVertexAttribPointer(
+      attrib, dl.size, dl.type, dl.normalized, dl.stride,
+      reinterpret_cast<void *>(static_cast<uintptr_t>(dl.offset)));
   glVertexAttribDivisor(attrib, dl.divisor);
-  this->unbind();
-  glBindBuffer(GL_ARRAY_BUFFER, 0);
   CheckGLError("Error in set_attrib VAO");
 }
 void VAO::use() { glBindVertexArray(vid); }

--- a/src/RGL.cpp
+++ b/src/RGL.cpp
@@ -324,64 +324,6 @@ void GBuffer::bindSamplers(RShaderProgram &apr) {
   apr.setFlag("noisetex", noisetex.getUnit());
 }
 
-RShader::RShader() {}
-RShader::~RShader() { glDeleteShader(sid); }
-
-bool RShader::charload(const GLchar *src, GLenum type) {
-  if (!src)
-    return false;
-  tp = type;
-  sid = glCreateShader(type);
-  glShaderSource(sid, 1, &src, NULL);
-  glCompileShader(sid);
-  int iCompilationStatus;
-  glGetShaderiv(sid, GL_COMPILE_STATUS, &iCompilationStatus);
-  if (iCompilationStatus == GL_FALSE) {
-    std::cerr<<"Could not compile shader:"<<std::endl;
-    char buffer[512];
-    glGetShaderInfoLog(sid, 512, NULL, buffer);
-    std::cerr<<buffer<<std::endl;
-    return false;
-  }
-  int bufflen;
-  glGetShaderiv(sid, GL_INFO_LOG_LENGTH, &bufflen);
-  if (bufflen > 1) {
-    std::vector<GLchar> log_string(bufflen + 1);
-    glGetShaderInfoLog(sid, bufflen, 0, log_string.data());
-  }
-
-  return true;
-}
-
-bool RShader::load(const char *fileName, GLenum type) {
-  return charload(read_file(fileName).c_str(), type);
-}
-
-RShaderProgram::RShaderProgram() { pid = glCreateProgram(); }
-RShaderProgram::~RShaderProgram() { glDeleteProgram(pid); }
-
-bool RShaderProgram::init(RShader *shader_list, uint nshaders) {
-  fori(0, nshaders) glAttachShader(pid, shader_list[i].id());
-  glLinkProgram(pid);
-  int isLinked = 0;
-  glGetProgramiv(pid, GL_LINK_STATUS, (int *)&isLinked);
-  if (isLinked == GL_FALSE) {
-    int bl = 0;
-    glGetProgramiv(pid, GL_INFO_LOG_LENGTH, &bl);
-    std::vector<GLchar> infoLog(bl);
-    glGetProgramInfoLog(pid, bl, &bl, &infoLog[0]);
-    printf("%s\n", infoLog.data());
-  }
-  return true;
-}
-
-void RShaderProgram::use() { glUseProgram(pid); }
-void RShaderProgram::unbind() { glUseProgram(0); }
-
-void RShaderProgram::setFlag(const GLchar *flag, int val) {
-  glProgramUniform1i(pid, glGetUniformLocation(pid, flag), val);
-}
-
 RGLContext::RGLContext(std::shared_ptr<System> sys, SDL_Window *w) : sys(sys) {
   sys->log<System::DEBUG>("[RGLContext] Initialized");
   init(w);

--- a/src/RGL.cpp
+++ b/src/RGL.cpp
@@ -361,13 +361,6 @@ void GBuffer::handle_resize(int new_fwidth, int new_fheight) {
   CheckGLError("Error at GBuffer resize");
 }
 
-void GBuffer::bindSamplers(RShaderProgram &apr) {
-  apr.setFlag("ctex", ctex.getUnit());
-  apr.setFlag("dtex", dtex.getUnit());
-  apr.setFlag("ndtex", normdtex.getUnit());
-  apr.setFlag("ptex", ptex.getUnit());
-  apr.setFlag("noisetex", noisetex.getUnit());
-}
 
 RGLContext::RGLContext(std::shared_ptr<System> sys, SDL_Window *w) : sys(sys) {
   sys->log<System::DEBUG>("[RGLContext] Initialized");

--- a/src/RGL.cpp
+++ b/src/RGL.cpp
@@ -232,7 +232,7 @@ FBO::FBO(std::shared_ptr<System> sys, glm::int2 resolution)
   shs[0].charload(shaders_quad_vs, GL_VERTEX_SHADER);
   shs[1].charload(shaders_quad_fs, GL_FRAGMENT_SHADER);
   pr.init(shs, 2);
-  pr.setFlag("ctex", ctex.getUnit());
+  pr.setUniform<GLint>("ctex", ctex.getUnit());
   CheckGLError("Error at texture creation");
 }
 

--- a/src/RGL.cpp
+++ b/src/RGL.cpp
@@ -198,12 +198,8 @@ void RTex::init(GLenum ifmt, GLenum efmt, GLenum dtp, glm::int2 size) {
 }
 
 RTex::~RTex() { glDeleteTextures(1, &tid); }
-void RTex::use() {
-  glBindTexture(tp, tid);
-}
-void RTex::unbind() {
-  glBindTexture(tp, 0);
-}
+void RTex::use() { glBindTexture(tp, tid); }
+void RTex::unbind() { glBindTexture(tp, 0); }
 
 bool RTex::upload(const void *data) {
   glTextureSubImage2D(tid, 0, 0, 0, size.x, size.y, format[1], format[2], data);

--- a/src/RGL.h
+++ b/src/RGL.h
@@ -118,7 +118,7 @@ public:
   GLuint id() { return this->fid; }
   void draw();
 
-  glm::vec4 getPixel(int x, int y);
+  glm::u8vec4 getPixel(int x, int y);
   Uint8 *getColorData();
 
   void setFormat(GLenum ifmt, GLenum efmt, GLenum dtp);

--- a/src/RGL.h
+++ b/src/RGL.h
@@ -28,6 +28,11 @@ class VBO {
 public:
   VBO();
   ~VBO();
+  VBO(VBO &&other) noexcept;
+  VBO &operator=(VBO &&other) noexcept;
+  VBO(const VBO &) = delete;
+  VBO &operator=(const VBO &) = delete;
+
   void init(GLenum type, GLbitfield flags, const DataLayout &dl);
   void init(GLenum type, GLbitfield flags);
   void *map(GLenum usage = GL_WRITE_ONLY);
@@ -58,6 +63,15 @@ class VAO {
 public:
   VAO();
   ~VAO();
+
+  // Move support
+  VAO(VAO &&other) noexcept;
+  VAO &operator=(VAO &&other) noexcept;
+
+  // Optional: disable copy
+  VAO(const VAO &) = delete;
+  VAO &operator=(const VAO &) = delete;
+
   uint id() { return this->vid; }
   void set_attrib(uint attrib, const VBO &vbo, GLint binding);
   void use();

--- a/src/RGL.h
+++ b/src/RGL.h
@@ -48,8 +48,8 @@ public:
   DataLayout get_layout() const { return this->layout; }
   void reset();
 
-  void use();
-  void unbind();
+  void use() const;
+  void unbind() const;
 
 private:
   GLuint vid;

--- a/src/RGL.h
+++ b/src/RGL.h
@@ -151,8 +151,11 @@ public:
   ~GBuffer();
   float *getDepthData();
 
-  void bindSamplers(RShaderProgram &apr);
-
+  GLint getDepthUnit() { return dtex.getUnit(); }
+  GLint getPositionUnit() { return ptex.getUnit(); }
+  GLint getNormalDepthUnit() { return normdtex.getUnit(); }
+  GLint getNoiseUnit() { return noisetex.getUnit(); }
+  GLint getColorUnit() { return ctex.getUnit(); }
   void handle_resize(int new_fwidth, int new_fheight);
 
   RShaderProgram pr;

--- a/src/RGL.h
+++ b/src/RGL.h
@@ -1,10 +1,10 @@
 #ifndef RGL_H
 #define RGL_H
-#include "RFile.h"
+#include "RShaderProgram.h"
 #include "System.h"
-#include "defines.h"
 #include "glm/gtx/compatibility.hpp"
 #include <array>
+#include <memory>
 #include <vector>
 
 namespace superpunto {

--- a/src/RGL.h
+++ b/src/RGL.h
@@ -124,7 +124,6 @@ public:
   void setFormat(GLenum ifmt, GLenum efmt, GLenum dtp);
 
   inline glm::int2 getSize() { return ctex.getSize(); }
-  void bindColorTex(RShaderProgram &apr);
   GLuint getTexUnit() { return ctex.getUnit(); }
 
   void handle_resize(int new_fwidth, int new_fheight);

--- a/src/RGL.h
+++ b/src/RGL.h
@@ -108,34 +108,6 @@ private:
   static GLuint unit_counter;
 };
 
-class RShader {
-public:
-  RShader();
-  ~RShader();
-  bool charload(const GLchar *src, GLenum type);
-  bool load(const char *fileName, GLenum type);
-  GLuint id() const { return this->sid; }
-
-private:
-  GLenum tp;
-  GLuint sid;
-};
-
-class RShaderProgram {
-public:
-  RShaderProgram();
-  ~RShaderProgram();
-  bool init(RShader *shader_list, uint nshaders);
-  GLuint id() const { return this->pid; }
-  void setFlag(const GLchar *flag, int val);
-  operator GLuint() const { return this->pid; }
-  void use();
-  void unbind();
-
-private:
-  uint pid;
-};
-
 class FBO {
 public:
   FBO(std::shared_ptr<System> sys, glm::int2 resolution);

--- a/src/RGL.h
+++ b/src/RGL.h
@@ -73,7 +73,7 @@ public:
   VAO &operator=(const VAO &) = delete;
 
   uint id() { return this->vid; }
-  void set_attrib(uint attrib, const VBO &vbo, GLint binding);
+  void set_attrib(uint attrib, const VBO &vbo);
   void use();
   void unbind();
 

--- a/src/RGL.h
+++ b/src/RGL.h
@@ -35,12 +35,13 @@ public:
 
   void init(GLenum type, GLbitfield flags, const DataLayout &dl);
   void init(GLenum type, GLbitfield flags);
-  void *map(GLenum usage = GL_WRITE_ONLY);
-  void unmap();
+  void *map(GLenum usage = GL_WRITE_ONLY) const;
+  void unmap() const;
   bool initmem(GLenum type, GLbitfield flags, GLsizeiptr size,
                const void *data);
   bool initmem(GLsizeiptr size, const void *data);
-  bool upload(GLenum type, GLintptr offset, GLsizeiptr size, const void *data);
+  bool upload(GLenum type, GLintptr offset, GLsizeiptr size,
+              const void *data) const;
   bool upload(GLintptr offset, GLsizeiptr size, const void *data);
 
   uint id() const { return this->vid; }

--- a/src/RParticleRenderer.cpp
+++ b/src/RParticleRenderer.cpp
@@ -183,19 +183,18 @@ void RParticleRenderer::render_picked() {
     glDrawElementsInstancedBaseInstance(GL_LINE_STRIP, NVERTEX, GL_UNSIGNED_INT,
                                         NULL, 1, picked[1]);
   if (picked[1] >= 0 && picked[0] >= 0) {
+    glm::vec3 pointA, pointB;
+    for (int i = 0; i < 3; ++i) {
+      pointA[i] = particles.pos[3 * picked[0] + i] * gscale;
+      pointB[i] = particles.pos[3 * picked[1] + i] * gscale;
+    }
     linepr.use();
-
-    float lineptr[6];
-    fori(0, 3) forj(0, 2) lineptr[i + 3 * j] = particles.pos[3 * picked[j] + i];
-
-    lines_vbo.upload(0, 6 * sizeof(float), (const void *)&lineptr[0]);
-    line_vao.use();
-    glLineWidth(3.3f);
+    dummy_vao.use();
     linepr.setUniform<glm::mat4>("MVP", MVP);
+    linepr.setUniform<glm::vec3>("pointA", pointA);
+    linepr.setUniform<glm::vec3>("pointB", pointB);
+    glLineWidth(5.3f);
     glDrawArrays(GL_LINES, 0, 2);
-    glLineWidth(1.0f);
-    pr.use();
-    spheres_vao.use();
   }
   pr.setUniform<GLfloat>("pickscale", 1.0f);
   pr.setUniform<GLint>("drawing_picked", 0);

--- a/src/RParticleRenderer.cpp
+++ b/src/RParticleRenderer.cpp
@@ -108,8 +108,6 @@ bool RParticleRenderer::init_shaders() {
 
   ssaofbo.setFormat(GL_R32F, GL_RED, GL_FLOAT);
   CheckGLError("Error in init_shaders");
-
-  return true;
 }
 bool RParticleRenderer::init_uniforms() {
   sys->log<System::DEBUG>("[ParticleRenderer] Init uniforms...    ");
@@ -146,7 +144,7 @@ bool RParticleRenderer::init_uniforms() {
   return true;
 }
 
-bool RParticleRenderer::upload_instances(ParticleData pdata) {
+void RParticleRenderer::upload_instances(ParticleData pdata) {
   int N = pdata.N;
   if (N > maxN) {
     sys->log<System::DEBUG>(

--- a/src/RParticleRenderer.cpp
+++ b/src/RParticleRenderer.cpp
@@ -102,11 +102,6 @@ void RParticleRenderer::init_shaders() {
   ssaofbo.setFormat(GL_R32F, GL_RED, GL_FLOAT);
   CheckGLError("Error in init_shaders");
 }
-  sys->log<System::DEBUG>("[ParticleRenderer] Init uniforms...    ");
-  pr.use();
-  this->uniMVP = glGetUniformLocation(pr.id(), "MVP");
-  this->unimodel = glGetUniformLocation(pr.id(), "model");
-  this->uninormalmodel = glGetUniformLocation(pr.id(), "normal_model");
 
 void RParticleRenderer::init_uniforms() {
   sys->log<System::DEBUG>("[ParticleRenderer] Init uniforms...    ");

--- a/src/RParticleRenderer.cpp
+++ b/src/RParticleRenderer.cpp
@@ -211,12 +211,12 @@ void RParticleRenderer::geometry_pass() {
   pr.use();
   pr.setUniform<glm::mat4>("MVP", MVP);
   glm::mat4 normal_model = transpose(inverse(model));
-  glUniformMatrix4fv(uninormalmodel, 1, GL_FALSE, glm::value_ptr(normal_model));
   spheres_vao.use();
   sphere_vbos[1].use(); // indices
   glDrawElementsInstanced(GL_TRIANGLES, NVERTEX, GL_UNSIGNED_INT, NULL,
                           particles.N);
   if (!picking)
+  pr.setUniform<glm::mat4>("normal_model", normal_model);
   if (!picking) {
     render_picked();
   }

--- a/src/RParticleRenderer.cpp
+++ b/src/RParticleRenderer.cpp
@@ -38,7 +38,7 @@ void RParticleRenderer::handle_resize(uint fw, uint fh) {
   ssaopr.unbind();
   CheckGLError("Error at resize");
 }
-bool RParticleRenderer::init_buffers() {
+void RParticleRenderer::init_buffers() {
   sys->log<System::DEBUG>("[ParticleRenderer]Init buffers...     ");
 
   DataLayout dl;
@@ -49,30 +49,27 @@ bool RParticleRenderer::init_buffers() {
   init_sphere();
   init_instance_vbos();
   init_vao();
-  return true;
 }
-bool RParticleRenderer::init_sphere() { // Config and upload sphere vertices
   DataLayout dl;
   dl.init(3, 3 * sizeof(float), GL_FLOAT, 0);
   sphere_vbos[0].init(GL_ARRAY_BUFFER, GL_MAP_READ_BIT, dl);
   sphere_vbos[1].init(GL_ELEMENT_ARRAY_BUFFER, GL_MAP_READ_BIT);
   fill_sphere_vbos(sphere_vbos[0], sphere_vbos[1]);
+void RParticleRenderer::init_sphere() {
   CheckGLError("Error in init_sphere");
-  return true;
 }
 
-bool RParticleRenderer::init_vao() { // Configure Vertex Array Objects
   spheres_vao.set_attrib(attribs["in_vertex"], sphere_vbos[0], 0);
   CheckGLError("Error in vertex");
   spheres_vao.set_attrib(attribs["pos"], instances_vbos[0], 1);
   spheres_vao.set_attrib(attribs["color"], instances_vbos[1], 2);
   spheres_vao.set_attrib(attribs["scale"], instances_vbos[2], 3);
   line_vao.set_attrib(0, lines_vbo, 0);
+void RParticleRenderer::init_vao() {
   CheckGLError("Error in init_vao");
-  return true;
 }
 
-bool RParticleRenderer::init_instance_vbos() {
+void RParticleRenderer::init_instance_vbos() {
   DataLayout dl;
   dl.init(3, 3 * sizeof(float), GL_FLOAT, 0, 1);
   instances_vbos[0].init(GL_ARRAY_BUFFER, GL_DYNAMIC_STORAGE_BIT, dl);
@@ -83,10 +80,9 @@ bool RParticleRenderer::init_instance_vbos() {
   instances_vbos[1].initmem(maxN * sizeof(float) * 3, NULL); // colors
   instances_vbos[2].initmem(maxN * sizeof(float) * 1, NULL); // scales
   CheckGLError("Error in init_instance_vbos");
-  return true;
 }
 
-bool RParticleRenderer::init_shaders() {
+void RParticleRenderer::init_shaders() {
   sys->log<System::DEBUG>("[ParticleRenderer] Init shaders...     ");
   RShader shs[2];
   shs[0].charload(shaders_geom_vs, GL_VERTEX_SHADER);
@@ -109,7 +105,6 @@ bool RParticleRenderer::init_shaders() {
   ssaofbo.setFormat(GL_R32F, GL_RED, GL_FLOAT);
   CheckGLError("Error in init_shaders");
 }
-bool RParticleRenderer::init_uniforms() {
   sys->log<System::DEBUG>("[ParticleRenderer] Init uniforms...    ");
   pr.use();
   this->uniMVP = glGetUniformLocation(pr.id(), "MVP");
@@ -141,7 +136,6 @@ bool RParticleRenderer::init_uniforms() {
 
   linepr.unbind();
   CheckGLError("Error in init_uniforms");
-  return true;
 }
 
 void RParticleRenderer::upload_instances(ParticleData pdata) {
@@ -163,9 +157,7 @@ void RParticleRenderer::upload_instances(ParticleData pdata) {
                            (const void *)pdata.scales);
   this->particles = pdata;
   float3 L = pdata.L;
-
   box.setSize(glm::vec3(L.x, L.y, L.z));
-  return true;
 }
 
 void RParticleRenderer::update() { RRenderer::update(); }

--- a/src/RParticleRenderer.cpp
+++ b/src/RParticleRenderer.cpp
@@ -118,11 +118,15 @@ void RParticleRenderer::init_shaders() {
   glUniform1f(glGetUniformLocation(pr.id(), "zfar"), zfar);
   pr.unbind();
 
-  gBuffer.bindSamplers(lightpr);
-  gBuffer.bindSamplers(ssaopr);
 
   lightpr.setFlag("SSAOtex", ssaofbo.getTexUnit());
 
+  lightpr.setUniform<GLint>("ctex", gBuffer.getColorUnit());
+  lightpr.setUniform<GLint>("ndtex", gBuffer.getNormalDepthUnit());
+  lightpr.setUniform<GLint>("ptex", gBuffer.getPositionUnit());
+  lightpr.setUniform<GLint>("SSAOtex", ssaofbo.getTexUnit());
+  ssaopr.setUniform<GLint>("ndtex", gBuffer.getNormalDepthUnit());
+  ssaopr.setUniform<GLint>("noisetex", gBuffer.getNoiseUnit());
   auto op = sys->getInputOptions();
   ssaopr.use();
   glUniform1f(glGetUniformLocation(ssaopr.id(), "FWIDTH"), (float)op.target_FW);

--- a/src/RParticleRenderer.cpp
+++ b/src/RParticleRenderer.cpp
@@ -154,18 +154,13 @@ int RParticleRenderer::pick(int x, int y, int pickindex) {
   this->picking = true;
   geometry_pass();
   pr.use();
-  glm::vec4 pixel = gBuffer.getPixel(x, y);
-
-  this->picked[pickindex] =
-      pixel[0] + 256 * pixel[1] + 256 * 256 * pixel[2] - 1;
-
-  // Two colors identify the same index to gain precision,
-  //"only" 255^3/2 differenciable objects
-  if (picked[pickindex] >= 0)
-    picked[pickindex] /= 2;
-
   pr.setUniform<GLint>("picking", 0);
+  auto pixel = gBuffer.getPixel(x, y);
+  uint id = pixel.r + 256u * pixel.g + 256u * 256u * pixel.b +
+            256u * 256u * 256u * pixel.a;
+  picked[pickindex] = int(id) - 1;
   this->picking = false;
+  System::log<System::DEBUG>("Picked %d", pickindex);
   return picked[pickindex];
 }
 

--- a/src/RParticleRenderer.cpp
+++ b/src/RParticleRenderer.cpp
@@ -31,11 +31,8 @@ void RParticleRenderer::handle_resize(uint fw, uint fh) {
   fbo.handle_resize(fw, fh);
   ssaofbo.handle_resize(fw, fh);
   gBuffer.handle_resize(fw, fh);
-
-  ssaopr.use();
-  glUniform1f(glGetUniformLocation(ssaopr.id(), "FWIDTH"), (float)fw);
-  glUniform1f(glGetUniformLocation(ssaopr.id(), "FHEIGHT"), (float)fh);
-  ssaopr.unbind();
+  ssaopr.setUniform<float>("FWIDTH", fw);
+  ssaopr.setUniform<float>("FHEIGHT", fh);
   CheckGLError("Error at resize");
 }
 void RParticleRenderer::init_buffers() {

--- a/src/RParticleRenderer.cpp
+++ b/src/RParticleRenderer.cpp
@@ -1,5 +1,4 @@
 #include "RParticleRenderer.h"
-
 namespace superpunto {
 // Vertex per sphere in fill_vbos
 #define NVERTEX 240
@@ -169,6 +168,7 @@ int RParticleRenderer::pick(int x, int y, int pickindex) {
   this->picking = false;
   return picked[pickindex];
 }
+
 void RParticleRenderer::render_picked() {
   if (picked[0] < 0 && picked[1] < 0)
     return;
@@ -217,10 +217,12 @@ void RParticleRenderer::geometry_pass() {
   glDrawElementsInstanced(GL_TRIANGLES, NVERTEX, GL_UNSIGNED_INT, NULL,
                           particles.N);
   if (!picking)
+  if (!picking) {
     render_picked();
-
-  if (!cfg.nobox)
+  }
+  if (!cfg.nobox){
     box.draw();
+  }
 }
 
 void RParticleRenderer::light_pass() {
@@ -237,15 +239,14 @@ void RParticleRenderer::SSAO_pass() {
   static const int nsamples = 129;
   static glm::vec4 points[nsamples];
   static bool gen_points = true;
-
   if (gen_points) {
     fori(0, nsamples) {
-      /*We will sample depths in a semisphere*/
+      // We will sample depths in a semisphere
       auto randEsp = []() { return rand() / (float)RAND_MAX; };
       glm::vec4 sample = glm::normalize(glm::vec4(
           randEsp() * 2.0 - 1.0, randEsp() * 2.0 - 1.0, randEsp(), 0));
       float scale = float(i) / nsamples;
-      /*We want the samples to be preferently close*/
+      // We want the samples to be preferently close
       scale = lerp(0.1f, 1.0f, scale * scale);
       sample *= scale;
       points[i] = sample;
@@ -253,11 +254,9 @@ void RParticleRenderer::SSAO_pass() {
     ssaopr.setUniform<glm::vec4>("points", points, nsamples);
     gen_points = false;
   }
-
   ssaofbo.use();
   glDisable(GL_DEPTH_TEST);
   ssaopr.use();
-
   dummy_vao.use();
   glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }
@@ -266,7 +265,6 @@ void RParticleRenderer::draw() {
   geometry_pass();
   SSAO_pass();
   light_pass();
-
   fbo.draw();
   RRenderer::display();
 }

--- a/src/RParticleRenderer.cpp
+++ b/src/RParticleRenderer.cpp
@@ -265,6 +265,7 @@ void RParticleRenderer::draw() {
   geometry_pass();
   SSAO_pass();
   light_pass();
+  glDisable(GL_DEPTH_TEST);
   fbo.draw();
   RRenderer::display();
 }

--- a/src/RParticleRenderer.cpp
+++ b/src/RParticleRenderer.cpp
@@ -299,12 +299,6 @@ void RParticleRenderer::SSAO_pass() {
   ssaofbo.unbind();
 }
 
-void RParticleRenderer::SSAOrad(float inc) {
-  static float rad = 0.4f;
-  rad += inc;
-  glProgramUniform1f(ssaopr.id(), glGetUniformLocation(ssaopr.id(), "radius"),
-                     rad);
-}
 void RParticleRenderer::draw() {
   geometry_pass();
   SSAO_pass();

--- a/src/RParticleRenderer.cpp
+++ b/src/RParticleRenderer.cpp
@@ -161,10 +161,8 @@ int RParticleRenderer::pick(int x, int y, int pickindex) {
   pr.use();
   pr.setUniform<GLint>("picking", 1);
   this->picking = true;
-  pr.unbind();
   geometry_pass();
   pr.use();
-  pr.unbind();
   glm::vec4 pixel = gBuffer.getPixel(x, y);
 
   this->picked[pickindex] =
@@ -209,6 +207,7 @@ void RParticleRenderer::render_picked() {
   }
   pr.setUniform<GLfloat>("pickscale", 1.0f);
   pr.setUniform<GLint>("drawing_picked", 0);
+  pr.unbind();
 }
 
 void RParticleRenderer::geometry_pass() {
@@ -230,11 +229,6 @@ void RParticleRenderer::geometry_pass() {
 
   if (!cfg.nobox)
     box.draw();
-
-  sphere_vbos[1].unbind(); // indices
-  spheres_vao.unbind();
-  pr.unbind();
-  gBuffer.unbind();
 }
 
 void RParticleRenderer::light_pass() {
@@ -244,10 +238,6 @@ void RParticleRenderer::light_pass() {
   lightpr.setUniform<glm::vec3>("viewPos", cam->pos);
   dummy_vao.use();
   glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-  dummy_vao.unbind();
-
-  lightpr.unbind();
-  fbo.unbind();
 }
 
 GLfloat lerp(GLfloat a, GLfloat b, GLfloat f) { return a + f * (b - a); }
@@ -278,10 +268,6 @@ void RParticleRenderer::SSAO_pass() {
 
   dummy_vao.use();
   glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-  dummy_vao.unbind();
-
-  ssaopr.unbind();
-  ssaofbo.unbind();
 }
 
 void RParticleRenderer::draw() {

--- a/src/RParticleRenderer.h
+++ b/src/RParticleRenderer.h
@@ -14,7 +14,6 @@ public:
   void upload_instances(ParticleData pdata) override;
 
   void update() override;
-  void SSAOrad(float inc);
 
   void draw() override;
 

--- a/src/RParticleRenderer.h
+++ b/src/RParticleRenderer.h
@@ -2,9 +2,16 @@
 #define RPARTICLERENDERER_H
 #include "RRenderer.h"
 #include "shaders.h"
-
+#include "LOD.h"
 #include <map>
 namespace superpunto {
+struct Sphere {
+  Sphere(int lod);
+
+  VBO vertex_vbos[2];    // Vertex, index
+  int number_vertex;
+};
+
 class RParticleRenderer : public RRenderer {
 public:
   RParticleRenderer(std::shared_ptr<System> sys, std::shared_ptr<RWindow> w,
@@ -43,18 +50,16 @@ private:
   FBO fbo, ssaofbo;
   GBuffer gBuffer;
 
-  VBO sphere_vbos[2];    // Vertex, index
-  VBO instances_vbos[3]; // pos, color, radius
-
-  VBO lines_vbo; // lines start/end
+  std::vector<Sphere> sphere_geometries;
+  std::vector<VAO> sphere_vaos;
+  VBO vertex_vbos[2];
+  VBO instances_vbos[2]; // pos+scale, color
   int maxN;
-  VAO spheres_vao, dummy_vao, line_vao;
-  std::map<std::string, uint> attribs;
+  VAO dummy_vao;
   RShaderProgram pr, lightpr, ssaopr, linepr;
   bool picking = false;
+  LODProgram lod_program;
 };
-
-void fill_sphere_vbos(VBO &posVBO, VBO &indicesVBO);
 
 } // namespace superpunto
 #endif

--- a/src/RParticleRenderer.h
+++ b/src/RParticleRenderer.h
@@ -51,7 +51,6 @@ private:
   VAO spheres_vao, dummy_vao, line_vao;
   std::map<std::string, uint> attribs;
   RShaderProgram pr, lightpr, ssaopr, linepr;
-  GLuint uniMVP, unimodel, uninormalmodel;
   bool picking = false;
 };
 

--- a/src/RParticleRenderer.h
+++ b/src/RParticleRenderer.h
@@ -11,7 +11,7 @@ public:
                     std::shared_ptr<Camera> cam, float gscale);
   ~RParticleRenderer();
 
-  bool upload_instances(ParticleData pdata) override;
+  void upload_instances(ParticleData pdata) override;
 
   void update() override;
   void SSAOrad(float inc);

--- a/src/RParticleRenderer.h
+++ b/src/RParticleRenderer.h
@@ -26,14 +26,14 @@ public:
   glm::int2 getSize() override;
 
 private:
-  bool init_buffers();
-  bool init_sphere();
-  bool init_instance_vbos();
-  bool init_vao();
+  void init_buffers();
+  void init_sphere();
+  void init_instance_vbos();
+  void init_vao();
 
-  bool init_shaders();
+  void init_shaders();
 
-  bool init_uniforms();
+  void init_uniforms();
 
   void geometry_pass();
   void light_pass();

--- a/src/RRenderer.cpp
+++ b/src/RRenderer.cpp
@@ -8,7 +8,7 @@ RRenderer::RRenderer(std::shared_ptr<System> sys, std::shared_ptr<RWindow> in_w,
       textRenderer(sys, in_w), w(in_w) {
   picked[0] = picked[1] = -1;
   auto op = sys->getInputOptions();
-  textRenderer.setFont(op.fontName.c_str(),   int(op.target_FH / 10));
+  textRenderer.setFont(op.fontName.c_str(), int(op.target_FH / 10));
   auto resolution = w->getResolution();
   proj =
       glm::perspective(op.fov, resolution.x / (float)resolution.y, znear, zfar);

--- a/src/RRenderer.cpp
+++ b/src/RRenderer.cpp
@@ -27,18 +27,16 @@ void RRenderer::rotate_model(GLfloat angle, GLfloat x, GLfloat y, GLfloat z) {
   model = glm::rotate(model, angle, glm::vec3(x, y, z));
 }
 
-  void RRenderer::reset_model() {
-    model = glm::mat4();
-    view = cam->lookAt();
-    rotate_model(M_PI / 4.0f, 0.0f, 0.0f, 1.0f);
-    MVP = proj * view * model;
-  }
-
-void RRenderer::update() {
+void RRenderer::reset_model() {
+  model = glm::mat4();
   view = cam->lookAt();
   MVP = proj * view * model;
+}
 
+void RRenderer::update() {
   cam->update();
+  view = cam->lookAt();
+  MVP = proj * view * model;
 }
 
 void RRenderer::handle_event(SDL_Event &e) {}
@@ -70,7 +68,6 @@ Uint8 *RRenderer::getPixels() {
   size_t cdatasize = resolution.x * resolution.y * 4;
   if (cdata.size() != cdatasize)
     cdata.resize(cdatasize);
-
   glReadPixels(0, 0, resolution.x, resolution.y, GL_RGBA, GL_UNSIGNED_BYTE,
                (void *)cdata.data());
   return cdata.data();
@@ -80,8 +77,6 @@ glm::int2 RRenderer::getSize() {
   auto resolution = w->getResolution();
   return glm::int2(resolution.x, resolution.y);
 }
-
-
 
 RAxis::RAxis(std::shared_ptr<System> sys, std::shared_ptr<RWindow> w)
     : sys(sys), w(w), Xtext(sys, w), Ytext(sys, w), Ztext(sys, w) {

--- a/src/RRenderer.h
+++ b/src/RRenderer.h
@@ -64,7 +64,7 @@ namespace superpunto{
     void rotate_model(GLfloat angle, GLfloat x, GLfloat y, GLfloat z);
     void reset_model();
 
-    virtual bool upload_instances(ParticleData pdata) = 0;
+    virtual void upload_instances(ParticleData pdata) = 0;
 
     virtual int pick(int x, int y, int pickindex);
 

--- a/src/RShaderProgram.cpp
+++ b/src/RShaderProgram.cpp
@@ -1,0 +1,153 @@
+#include "RShaderProgram.h"
+#include "RFile.h"
+#include <glm/glm.hpp>
+#include <glm/gtc/type_ptr.hpp>
+#include <iostream>
+#include <vector>
+namespace superpunto {
+namespace detail {
+
+GLint safeGetUniformLocation(GLuint program, const GLchar *name) {
+  GLint loc = glGetUniformLocation(program, name);
+  if (loc == -1) {
+    System::log<System::ERROR>(
+        "[ShaderProgram] Uniform %s not found in program %d", name, program);
+  }
+  return loc;
+}
+} // namespace detail
+
+RShader::RShader() {}
+RShader::~RShader() { glDeleteShader(sid); }
+
+bool RShader::charload(const GLchar *src, GLenum type) {
+  if (!src)
+    return false;
+  tp = type;
+  sid = glCreateShader(type);
+  glShaderSource(sid, 1, &src, NULL);
+  glCompileShader(sid);
+  int iCompilationStatus;
+  glGetShaderiv(sid, GL_COMPILE_STATUS, &iCompilationStatus);
+  if (iCompilationStatus == GL_FALSE) {
+    std::cerr << "Could not compile shader:" << std::endl;
+    char buffer[512];
+    glGetShaderInfoLog(sid, 512, NULL, buffer);
+    std::cerr << buffer << std::endl;
+    return false;
+  }
+  int bufflen;
+  glGetShaderiv(sid, GL_INFO_LOG_LENGTH, &bufflen);
+  if (bufflen > 1) {
+    std::vector<GLchar> log_string(bufflen + 1);
+    glGetShaderInfoLog(sid, bufflen, 0, log_string.data());
+  }
+
+  return true;
+}
+
+bool RShader::load(const char *fileName, GLenum type) {
+  return charload(read_file(fileName).c_str(), type);
+}
+
+RShaderProgram::RShaderProgram() { pid = glCreateProgram(); }
+RShaderProgram::~RShaderProgram() { glDeleteProgram(pid); }
+
+bool RShaderProgram::init(RShader *shader_list, uint nshaders) {
+  fori(0, nshaders) glAttachShader(pid, shader_list[i].id());
+  glLinkProgram(pid);
+  int isLinked = 0;
+  glGetProgramiv(pid, GL_LINK_STATUS, (int *)&isLinked);
+  if (isLinked == GL_FALSE) {
+    int bl = 0;
+    glGetProgramiv(pid, GL_INFO_LOG_LENGTH, &bl);
+    std::vector<GLchar> infoLog(bl);
+    glGetProgramInfoLog(pid, bl, &bl, &infoLog[0]);
+    printf("%s\n", infoLog.data());
+  }
+  return true;
+}
+
+void RShaderProgram::use() { glUseProgram(pid); }
+
+void RShaderProgram::unbind() { glUseProgram(0); }
+
+template <>
+void RShaderProgram::setUniform<GLint>(const GLchar *flag, const GLint *val,
+                                       int count) {
+  GLint loc = detail::safeGetUniformLocation(pid, flag);
+  if (count == 1)
+    glProgramUniform1i(pid, loc, *val);
+  else
+    glProgramUniform1iv(pid, loc, count, val);
+}
+
+template <>
+void RShaderProgram::setUniform<GLuint>(const GLchar *flag, const GLuint *val,
+                                        int count) {
+  GLint loc = detail::safeGetUniformLocation(pid, flag);
+  if (count == 1)
+    glProgramUniform1ui(pid, loc, *val);
+  else
+    glProgramUniform1uiv(pid, loc, count, val);
+}
+
+template <>
+void RShaderProgram::setUniform<float>(const GLchar *flag, const float *val,
+                                       int count) {
+  GLint loc = detail::safeGetUniformLocation(pid, flag);
+  if (count == 1)
+    glProgramUniform1f(pid, loc, *val);
+  else
+    glProgramUniform1fv(pid, loc, count, val);
+}
+
+template <>
+void RShaderProgram::setUniform<glm::vec2>(const GLchar *flag,
+                                           const glm::vec2 *val, int count) {
+  GLint loc = detail::safeGetUniformLocation(pid, flag);
+  glProgramUniform2fv(pid, loc, count, glm::value_ptr(val[0]));
+}
+template <>
+void RShaderProgram::setUniform<glm::ivec2>(const GLchar *flag,
+                                            const glm::ivec2 *val, int count) {
+  GLint loc = detail::safeGetUniformLocation(pid, flag);
+  glProgramUniform2iv(pid, loc, count, glm::value_ptr(val[0]));
+}
+
+template <>
+void RShaderProgram::setUniform<glm::vec3>(const GLchar *flag,
+                                           const glm::vec3 *val, int count) {
+  GLint loc = detail::safeGetUniformLocation(pid, flag);
+  glProgramUniform3fv(pid, loc, count, glm::value_ptr(val[0]));
+}
+
+template <>
+void RShaderProgram::setUniform<glm::vec4>(const GLchar *flag,
+                                           const glm::vec4 *val, int count) {
+  GLint loc = detail::safeGetUniformLocation(pid, flag);
+  glProgramUniform4fv(pid, loc, count, glm::value_ptr(val[0]));
+}
+
+template <>
+void RShaderProgram::setUniform<glm::mat2>(const GLchar *flag,
+                                           const glm::mat2 *val, int count) {
+  GLint loc = detail::safeGetUniformLocation(pid, flag);
+  glProgramUniformMatrix2fv(pid, loc, count, GL_FALSE, glm::value_ptr(val[0]));
+}
+
+template <>
+void RShaderProgram::setUniform<glm::mat3>(const GLchar *flag,
+                                           const glm::mat3 *val, int count) {
+  GLint loc = detail::safeGetUniformLocation(pid, flag);
+  glProgramUniformMatrix3fv(pid, loc, count, GL_FALSE, glm::value_ptr(val[0]));
+}
+
+template <>
+void RShaderProgram::setUniform<glm::mat4>(const GLchar *flag,
+                                           const glm::mat4 *val, int count) {
+  GLint loc = detail::safeGetUniformLocation(pid, flag);
+  glProgramUniformMatrix4fv(pid, loc, count, GL_FALSE, glm::value_ptr(val[0]));
+}
+
+} // namespace superpunto

--- a/src/RShaderProgram.h
+++ b/src/RShaderProgram.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "System.h"
+namespace superpunto {
+class RShader {
+public:
+  RShader();
+  ~RShader();
+  bool charload(const GLchar *src, GLenum type);
+  bool load(const char *fileName, GLenum type);
+  GLuint id() const { return this->sid; }
+
+private:
+  GLenum tp;
+  GLuint sid;
+};
+
+class RShaderProgram {
+public:
+  RShaderProgram();
+  ~RShaderProgram();
+  bool init(RShader *shader_list, uint nshaders);
+  GLuint id() const { return this->pid; }
+  template <typename T>
+  void setUniform(const GLchar *flag, const T *val, int count);
+  template <typename T> void setUniform(const GLchar *flag, const T &val) {
+    setUniform(flag, &val, 1);
+  }
+
+  operator GLuint() const { return this->pid; }
+  void use();
+  void unbind();
+
+private:
+  GLuint pid;
+};
+} // namespace superpunto

--- a/src/RTextRenderer.cpp
+++ b/src/RTextRenderer.cpp
@@ -66,7 +66,7 @@ bool RTextRenderer::setText(const char *text, int x, int y, float sf) {
 
   if (tex.id() == 0) {
     tex.init(GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE, glm::int2(surf->w, surf->h));
-    pr->setFlag("ctex", tex.getUnit());
+    pr->setUniform<GLint>("ctex", tex.getUnit());
   } else
     tex.resize(surf->w, surf->h);
   this->size = glm::vec2(surf->w / (float)w->getResolution().x,
@@ -99,7 +99,7 @@ bool RTextRenderer::move(int x, int y) {
   return true;
 }
 void RTextRenderer::draw() {
-  pr->setFlag("ctex", tex.getUnit());
+  pr->setUniform<GLint>("ctex", tex.getUnit());
   pr->use();
   glUniform1f(glGetUniformLocation(pr->id(), "fontsize_multiplicator"),
               size_factor);

--- a/src/System.h
+++ b/src/System.h
@@ -6,7 +6,7 @@
 #include<cstdio>
 #include<GL/glew.h>
 #include<SDL2/SDL.h>
-#define SUPERPUNTO_MAJOR 4
+#define SUPERPUNTO_MAJOR 5
 #define SUPERPUNTO_MINOR 0
 #define xSPUNTOSTR(s) SPUNTOSTR(s)
 #define SPUNTOSTR(s) #s

--- a/src/System.h
+++ b/src/System.h
@@ -11,7 +11,7 @@
 #define xSPUNTOSTR(s) SPUNTOSTR(s)
 #define SPUNTOSTR(s) #s
 #ifndef USEFONT
-#define USEFONT /usr/share/fonts/dejavu-sans-mono-fonts/DejaVuSansMono.ttf
+#define USEFONT UbuntuMono-Regular.ttf
 #endif
 
 namespace superpunto{

--- a/src/icosphere.cpp
+++ b/src/icosphere.cpp
@@ -1,0 +1,135 @@
+#include "icosphere.h"
+#include <cassert>
+#include <cmath>
+#include <glm/glm.hpp>
+#include <tuple>
+#include <vector>
+
+namespace superpunto {
+
+//----------------------------------------------------------------------------
+// Helper: create a unit icosahedron.
+//
+// Returns a pair of vectors: the first contains 12 vertices and the second
+// contains 20 triangular faces (each face given as a glm::uvec3).
+//----------------------------------------------------------------------------
+std::pair<std::vector<Vertex>, std::vector<Face>> icosahedron() {
+  std::vector<Vertex> verts;
+  float phi = (1.f + std::sqrt(5.f)) / 2.f;
+  float norm = std::sqrt(1.f + phi * phi);
+
+  // Create six vertices (normalized so that the icosahedron is unit sized)
+  verts.push_back(Vertex(0, 1, phi) / norm);
+  verts.push_back(Vertex(0, -1, phi) / norm);
+  verts.push_back(Vertex(1, phi, 0) / norm);
+  verts.push_back(Vertex(-1, phi, 0) / norm);
+  verts.push_back(Vertex(phi, 0, 1) / norm);
+  verts.push_back(Vertex(-phi, 0, 1) / norm);
+
+  // Append the negatives of the above to obtain 12 vertices.
+  int n = verts.size();
+  for (int i = 0; i < n; i++) {
+    verts.push_back(-verts[i]);
+  }
+
+  // Define the 20 faces (using glm::uvec3 for unsigned indices)
+  std::vector<Face> faces = {
+      Face(0, 5, 1),  Face(0, 3, 5),  Face(0, 2, 3),  Face(0, 4, 2),
+      Face(0, 1, 4),  Face(1, 5, 8),  Face(5, 3, 10), Face(3, 2, 7),
+      Face(2, 4, 11), Face(4, 1, 9),  Face(7, 11, 6), Face(11, 9, 6),
+      Face(9, 8, 6),  Face(8, 10, 6), Face(10, 7, 6), Face(2, 11, 7),
+      Face(4, 9, 11), Face(1, 8, 9),  Face(5, 10, 8), Face(3, 7, 10)};
+
+  return {verts, faces};
+}
+
+//----------------------------------------------------------------------------
+// Helper: create a unit cube.
+//
+// Returns a pair of vectors: the first contains 8 vertices and the second
+// contains 12 triangular faces (each face given as a glm::uvec3).
+//----------------------------------------------------------------------------
+std::pair<std::vector<Vertex>, std::vector<Face>> cube() {
+  // Define 8 vertices for a unit cube.
+  std::vector<Vertex> verts = {{1, 1, 1},    {-1, 1, 1}, {-1, -1, 1},
+                               {1, -1, 1},   {1, 1, -1}, {-1, 1, -1},
+                               {-1, -1, -1}, {1, -1, -1}};
+  // Normalizethe vertices to make them unit length.
+  for (auto &v : verts) {
+    v = glm::normalize(v);
+  }
+  std::vector<Face> faces = {Face(0, 1, 2), Face(0, 2, 3), Face(4, 7, 6),
+                             Face(4, 6, 5), Face(0, 4, 5), Face(0, 5, 1),
+                             Face(3, 2, 6), Face(3, 6, 7), Face(0, 3, 7),
+                             Face(0, 7, 4), Face(1, 5, 6), Face(1, 6, 2)};
+  return {verts, faces};
+}
+
+//----------------------------------------------------------------------------
+// generate_icosphere()
+//----------------------------------------------------------------------------
+// Builds a unit icosahedron and subdivides each face using barycentric
+// interpolation with subdivision frequency 'nu'. For each base face, we
+// create a local grid of (nu+1)(nu+2)/2 vertices; each vertex is computed
+// as a normalized linear combination of the three triangle vertices.
+//----------------------------------------------------------------------------
+std::tuple<std::vector<Vertex>, std::vector<Face>> generate_icosphere(int nu) {
+  // Zero level is a cube
+  if (nu == 0) {
+    auto [baseVerts, baseFaces] = cube();
+    return {baseVerts, baseFaces};
+  }
+  // First obtain base icosahedron.
+  auto [baseVerts, baseFaces] = icosahedron();
+  if (nu == 1) {
+    return {baseVerts, baseFaces};
+  }
+  std::vector<Vertex> vertices;
+  std::vector<Face> faces;
+
+  // For each face of the icosahedron
+  for (const auto &f : baseFaces) {
+    // Get vertices A, B, C of the current face.
+    Vertex A = baseVerts[f.x];
+    Vertex B = baseVerts[f.y];
+    Vertex C = baseVerts[f.z];
+
+    // Create a local grid on the face.
+    // grid[i][j] holds the global index of the vertex computed at that grid
+    // point. The barycentric weights are:
+    //    wA = (nu - i - j) / nu,  wB = i / nu,  wC = j / nu.
+    std::vector<std::vector<int>> grid(nu + 1);
+    for (int i = 0; i <= nu; ++i) {
+      grid[i].resize(nu - i + 1);
+    }
+    for (int i = 0; i <= nu; ++i) {
+      for (int j = 0; j <= nu - i; ++j) {
+        int k = nu - i - j;
+        float wA = static_cast<float>(k) / nu;
+        float wB = static_cast<float>(i) / nu;
+        float wC = static_cast<float>(j) / nu;
+        Vertex pt = glm::normalize(A * wA + B * wB + C * wC);
+        int idx = vertices.size();
+        vertices.push_back(pt);
+        grid[i][j] = idx;
+      }
+    }
+    // Now create faces from the grid. Each little “cell” yields up to two
+    // triangles.
+    for (int i = 0; i < nu; ++i) {
+      for (int j = 0; j < nu - i; ++j) {
+        int idx0 = grid[i][j];
+        int idx1 = grid[i + 1][j];
+        int idx2 = grid[i][j + 1];
+        faces.push_back(Face(idx0, idx1, idx2));
+        if (j < nu - i - 1) { // there is a second triangle in the cell
+          int idx3 = grid[i + 1][j + 1];
+          faces.push_back(Face(idx1, idx3, idx2));
+        }
+      }
+    }
+  }
+  return {vertices, faces};
+}
+
+} // namespace superpunto

--- a/src/icosphere.h
+++ b/src/icosphere.h
@@ -2,7 +2,6 @@
 #include <vector>
 #include <tuple>
 #include <glm/glm.hpp>
-#include <GL/glew.h>
 
 namespace superpunto {
 

--- a/src/icosphere.h
+++ b/src/icosphere.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <vector>
+#include <tuple>
+#include <glm/glm.hpp>
+#include <GL/glew.h>
+
+namespace superpunto {
+
+  using Vertex = glm::vec3;
+  using Face = glm::uvec3;
+
+std::tuple<std::vector<Vertex>, std::vector<Face>> generate_icosphere(int nu);
+
+
+} // namespace superpunto

--- a/src/shaders/geom.vs
+++ b/src/shaders/geom.vs
@@ -1,15 +1,22 @@
 #version 450
 layout (location = 0) in vec3 in_vertex;
-layout (location = 1) in vec3 pos;
-layout (location = 2) in vec3 color;
-layout (location = 3) in float scale;
+layout(std430, binding = 1) readonly buffer Positions {
+  vec4 positions[];
+};
+layout(std430, binding = 2) readonly buffer Colors {
+  vec4 colors[];
+};
+layout(std430, binding = 3) readonly buffer Ids {
+  uint ids[];
+};
 
-uniform mat4 model;
 uniform mat4 normal_model;
 uniform mat4 MVP;
 uniform float pickscale;
 uniform float gscale;
-
+uniform int lod_base;
+uniform bool drawing_picked;
+uniform int pick_id;
 out vec3 Normal;
 out vec3 Color;
 out vec3 Pos;
@@ -17,10 +24,15 @@ out vec3 Pos;
 flat out int id;
 
 void main () {
-  id = gl_InstanceID+1;
-  vec3 vpos = pickscale*in_vertex*gscale*scale;
-  vec4 temp = vec4(vpos+pos*gscale, 1.0);
+  const uint real_id = drawing_picked?pick_id:ids[gl_InstanceID+lod_base];
+  const vec3 pos = positions[real_id].xyz;
+  const vec3 color = colors[real_id].rgb;
+  const float scale = positions[real_id].w;
+  id = int(real_id)+1;
+  const vec3 vpos = pickscale*in_vertex*gscale*scale;
+  const vec4 temp = vec4(vpos+pos*gscale, 1.0f);
   Color = color;
   gl_Position =  MVP*temp;
-  Normal =vec3(normal_model*vec4(vpos ,0.0));
+  const vec3 local_normal = normalize(vpos);
+  Normal = vec3(mat3(normal_model)*(local_normal));
 }

--- a/src/shaders/light.fs
+++ b/src/shaders/light.fs
@@ -1,11 +1,8 @@
 #version 450
 
 uniform sampler2D ctex;
-
-//uniform sampler2D dtex;
 uniform sampler2D ndtex;
 uniform sampler2D ptex;
-//uniform sampler2D noisetex;
 uniform sampler2D SSAOtex;
 
 layout(location = 0) out vec4 c;
@@ -16,58 +13,31 @@ struct Light{
 
 uniform Light light = {vec3(0, 0, 0), vec3(1, 1, 1)};
 uniform vec3 viewPos;
-uniform float ambient = 0.3f;//*vec3(0.25f, 0.20725f, 0.20725f);
-uniform float diffuseFactor = 0.4;// vec3(1.0f, 0.829f, 0.829f);
-uniform float specularFactor = 0.1;//vec3(0.296648f, 0.296648f, 0.296648f);
+uniform float ambient = 0.3f;
+uniform float diffuseFactor = 0.4f;
+uniform float specularFactor = 0.1f;
 uniform float shininess = 16.0f;
 
 void main (){
-
-  //float occ = texelFetch(SSAOtex, ivec2(gl_FragCoord.xy), 0).r;
-  // c = texture(noisetex, gl_FragCoord.xy/800, 0);
-  // c.w = 1;
-  // return;
   vec3 FragPos = texelFetch(ptex, ivec2(gl_FragCoord.xy), 0).xyz;
   vec4 Normal  = texelFetch(ndtex, ivec2(gl_FragCoord.xy), 0).xyzw;
   vec3 Color   = texelFetch(ctex, ivec2(gl_FragCoord.xy), 0).rgb;
-  //  float Specular   = texelFetch(ctex, ivec2(gl_FragCoord.xy), 0).w;
   float Occlusion = texelFetch(SSAOtex, ivec2(gl_FragCoord.xy), 0).r;
-  //TODO fix this, when there is no geom at this pixel
   if(Normal.w==1.0f){
     c = vec4(Color,1.0f);
     return;
   }
-  //c = vec4(Occlusion);
-  // return;
   float occ = pow(Occlusion, 1.2)*1.6f;
-  vec3 lighting = vec3(0);//Color*ambient);
-
-  vec3 viewDir = normalize(viewPos - FragPos);
-
-  /*Light comes from camera*/
-  vec3 lightDir= normalize(viewDir); //normalize(light.pos - FragPos); //Fixed light
-  vec3 diffuse = max(dot(Normal.xyz, lightDir), 0.0)*Color*light.color*diffuseFactor;
-
-  // vec3 reflectDir = reflect(-lightDir, Normal.xyz);
-  // float spec = pow( max(dot(viewDir, reflectDir), 0.0), shininess);
-
+  vec3 lighting = vec3(0);
+  vec3 viewDir = (normalize(viewPos - FragPos));
+  //Light comes from camera
+  vec3 lightDir= (normalize(viewDir));
+  vec3 diffuse = max(dot(Normal.xyz, lightDir), 0.0f)*Color*light.color*diffuseFactor;
   //Blinn-Phong
   vec3 hwdir = normalize(lightDir+viewDir);
-  float spec = pow(max(dot(Normal.xyz, hwdir), 0.0), shininess);
-
+  float spec = pow(max(dot(Normal.xyz, hwdir), 0.0f), shininess);
   vec3 specular = light.color*(spec*specularFactor);
-
-
-
-  // float dist = length(viewPos - FragPos);
-  // float attenuation = 1.0 / (1.0 + 0.0005 * dist + 0.00001 * dist * dist);
-
   lighting += diffuse + specular;
-
   lighting = lighting*occ + Color*ambient*occ;
- 
-  //  float z = Normal.w;
   c = vec4(lighting, 1.0f);
-  //c = vec4(occ,occ,occ, 1.0f);
-
 }

--- a/src/shaders/line.fs
+++ b/src/shaders/line.fs
@@ -1,7 +1,11 @@
 #version 450
+
 layout (location = 0) out vec4 outColor;
+layout(location = 1) out vec4 normalDepth;
 uniform vec3 color;
 
 void main() {
-  outColor = vec4(color, 1);
-}   
+  outColor = vec4(color, 1.0f);
+  //Excludes lines from SSAO effects
+  normalDepth = vec4(0,0,0,1);
+}

--- a/src/shaders/line.vs
+++ b/src/shaders/line.vs
@@ -1,13 +1,10 @@
 #version 450
 
-layout (location = 0) in vec3 in_vertex;
-
-uniform mat4 model;
 uniform mat4 MVP;
-uniform float gscale = 1.0f;
+uniform vec3 pointA;
+uniform vec3 pointB;
 
-void main () {
-  vec3 vpos = in_vertex*gscale;
-  vec4 temp = vec4(vpos, 1.0);
-  gl_Position =  MVP*temp;
+void main() {
+  vec3 pos = (gl_VertexID == 0) ? pointA : pointB;
+  gl_Position = MVP * vec4(pos, 1.0);
 }

--- a/src/shaders/lod.cs
+++ b/src/shaders/lod.cs
@@ -1,0 +1,81 @@
+#version 450
+layout(local_size_x = 256) in;
+
+layout(std430, binding = 0) readonly buffer ParticlePositions {
+    vec4 positions[]; // xyz = world position, w = radius (in world units)
+};
+
+layout(std430, binding = 1) buffer AllLODIndices {
+    uint lod_indices[];
+};
+
+layout(std430, binding = 2) buffer LODCounts {
+    uint counts[];
+};
+
+uniform mat4 modelview;
+uniform mat4 projection;
+uniform int num_lods;
+uniform int lod_stride;
+uniform ivec2 screen_resolution; // in pixels
+uniform float lod_pixel_min;    // pixel diameter for highest LOD
+uniform float lod_pixel_max;    // pixel diameter for lowest LOD
+uniform float lod_bias = 2.0f;  // bias for LOD mapping
+uniform float gscale;           // Global scale of the positions
+
+// Compute pixel diameter of a sphere projected onto the screen
+float compute_pixel_diameter(vec3 world_pos, float radius) {
+    const vec4 view_center = modelview * vec4(world_pos, 1.0);
+    const vec4 view_edge   = modelview * vec4(world_pos + vec3(radius, 0.0, 0.0), 1.0);
+    const vec4 clip_center = projection * view_center;
+    const vec4 clip_edge   = projection * view_edge;
+    const vec2 ndc_center = clip_center.xy / clip_center.w;
+    const vec2 ndc_edge   = clip_edge.xy / clip_edge.w;
+    const float screen_dist = 2*length(ndc_edge - ndc_center);
+    return screen_dist * screen_resolution.x; // X = horizontal pixel width
+}
+
+int mapLogLOD(float pixel_size, int N){
+    if(pixel_size<=17) return 0;
+    if(pixel_size<=20) return 1;
+    if(pixel_size<=80) return 2;
+    const float logMin = log2(lod_pixel_min);
+    const float logMax = log2(lod_pixel_max);
+    const float logD   = log2(clamp(pixel_size, lod_pixel_min, lod_pixel_max));
+    const float t = clamp((logD - logMin) / (logMax - logMin), 0.0, 1.0);
+    const float biased_t = pow(t, lod_bias);
+    return int(clamp(floor(biased_t * float(N)), 2.0, float(N-1)));
+}
+
+void main() {
+    const uint id = gl_GlobalInvocationID.x;
+    if (id >= positions.length()) return;
+    const vec4 global_pos = positions[id] * gscale;
+    const vec3 world_pos = global_pos.xyz;
+    const float radius = global_pos.w;
+    // Project to view space
+    vec4 view_pos = modelview * vec4(world_pos, 1.0);
+    if (view_pos.z > 0.0) return; // behind the camera
+    // Project to clip space
+    vec4 clip_pos = projection * view_pos;
+    if (clip_pos.w <= 0.0) return; // invalid projection
+    // Convert to NDC
+    vec3 ndc = clip_pos.xyz / clip_pos.w;
+    // Convert to screen space
+    vec2 screen_center = (ndc.xy * 0.5 + 0.5) * vec2(screen_resolution);
+    // Compute screen-space projected radius
+    float pixel_diameter = compute_pixel_diameter(world_pos, radius);
+    float pixel_radius = 0.5 * pixel_diameter;
+    // Check if the sphere is in screen space
+    if (screen_center.x + pixel_radius < 0.0 ||
+        screen_center.y + pixel_radius < 0.0 ||
+        screen_center.x - pixel_radius > float(screen_resolution.x) ||
+        screen_center.y - pixel_radius > float(screen_resolution.y))
+        return;
+    // Compute LOD and store
+    const float pixel_size = pixel_diameter;
+    const int lod = mapLogLOD(pixel_size, num_lods);
+    const uint offset = lod * lod_stride;
+    const uint index = atomicAdd(counts[lod], 1);
+    lod_indices[offset + index] = id;
+}

--- a/src/shaders/quad.fs
+++ b/src/shaders/quad.fs
@@ -6,7 +6,6 @@ uniform sampler2D ctex;
 out vec4 c;
 in vec2 V;
 void main (){
-  //c = texelFetch(ctex, ivec2(gl_FragCoord.xy), 0);
   c = texture(ctex, V);
   c.w = 1;
 }

--- a/src/shaders/ssao.fs
+++ b/src/shaders/ssao.fs
@@ -1,11 +1,8 @@
 #version 450
 
+uniform sampler2D ndtex; //Normal and linear depth tex
+uniform sampler2D noisetex; //4x4 noise texture
 
-// uniform sampler2D ctex; //Color tex
-// uniform sampler2D dtex; //depth buffer
- uniform sampler2D ndtex; //Normal and linear depth tex
-// uniform sampler2D ptex;  //Position buffer
- uniform sampler2D noisetex; //4x4 noise texture
 
 uniform float FWIDTH;
 uniform float FHEIGHT;
@@ -13,61 +10,44 @@ layout(location = 0) out float occ;
 
 const int NSAMPLES = 129;
 uniform vec4 points[NSAMPLES];
-/*This radius works well for radius 1 spheres*/
+//This radius works well for radius 1 spheres
 uniform float radius = 0.0515f;
 
 void main(){
   occ = 0.0;
   vec4 ND = texelFetch(ndtex, ivec2(gl_FragCoord.xy), 0);
-  
   vec3 N = ND.xyz;
   float my_depth = ND.w;
-
-  /*If this is a background pixel*/
+  //If this is a background pixel
   if(my_depth==1.0f)  return;
-
-  /*Create a random rotated base to randomize directions*/
+  //Create a random rotated base to randomize directions
   vec3 rv = texture(noisetex,
 		    ivec2(gl_FragCoord.xy/vec2(FWIDTH, FHEIGHT)/4.0f)).xyz;
   vec3 tangent = normalize(rv - N*dot(rv, N));
   vec3 bitan = cross(N, tangent);
   mat3 TBN = mat3(tangent, bitan, N);
-
   float z = my_depth;
   for(int i = 0; i<NSAMPLES; i++){
-    /*Rotate the direction*/
+    //Rotate the direction
     vec3 dir = TBN*points[i].xyz;
-    /*The sample point is at dir*radius from this point*/
+    //The sample point is at dir*radius from this point
     vec3 sm = vec3(gl_FragCoord.xy/vec2(FWIDTH, FHEIGHT), z) + dir*radius;
-    /*Mirror the points in the hidden hemisphere*/
-    if(dot(N, dir)<0.0) dir = -dir;
-    /*Recover the depth of the sample point*/
-    float their_depth =
-      textureLod(ndtex,
-		 sm.xy
-		 , 0).w;
-    /*depth is 1.0f in the background,
-      this prevents the background from occluding the model*/
-    if(their_depth!=1.0){
+    //Mirror the points in the hidden hemisphere
+    if(dot(N, dir)<0.0f) dir = -dir;
+    //Recover the depth of the sample point
+    float their_depth = textureLod(ndtex, sm.xy, 0.0f).w;
+    //depth is 1.0f in the background, this prevents the background from occluding the model
+    if(their_depth!=1.0f){
       float delta = (z-their_depth);
-      /*Occlude the pixel if the sample is closer*/
-      /*This number works well for radius one spheres, depends on ZNEAR and ZFAR*/
-      if( delta>4.0005e-5 ) {occ += 1.0*smoothstep(0,1, radius/abs(delta));}
+      //Occlude the pixel if the sample is closer
+      //This number works well for radius one spheres, depends on ZNEAR and ZFAR
+      if( delta>4.0005e-5f ) {
+	occ += smoothstep(0.0f, 1.0f, radius/abs(delta));
+      }
     }
-
   }
-  
-  occ = (1.0 - occ/NSAMPLES);
-  if(occ<0.0) occ=0.0;
+  occ = (1.0f - occ/NSAMPLES);
+  if(occ<0.0f) occ=0.0f;
 
- 
+
 }
-
-
-
-
-
-
-
-// c = texelFetch(ctex, ivec2(gl_FragCoord.xy), 0);
-// c.w = 1;

--- a/src/shaders/text.fs
+++ b/src/shaders/text.fs
@@ -1,4 +1,3 @@
-
 #version 450
 
 uniform sampler2D ctex;
@@ -7,7 +6,6 @@ out vec4 c;
 
 in vec2 vv;
 void main (){
-  
   vec2 vvv = vv;
   vvv.y = -vv.y;
   c = texture(ctex,  vvv);

--- a/src/shaders/text.vs
+++ b/src/shaders/text.vs
@@ -12,7 +12,6 @@ const vec2 v[4] =
 	   vec2(-1.0,  1.0),
 	   vec2( 1.0,  1.0));
 
-
 out vec2 vv;
 void main () {
   int id = gl_VertexID;


### PR DESCRIPTION
### Summary

This PR addresses several lingering issues in the codebase and introduces a new LOD (Level of Detail) system to improve performance and visual fidelity.

---

### Fixes

- Resolved minor bugs related to camera behavior and user controls.
- Fixed particle picking, which was unreliable with a large number of instances.
- Corrected rendering of wireframe outlines for picked particles — these were previously distorted by lighting effects.
- Eliminated instances of undefined OpenGL behavior that were being used inadvertently.
- Improved error handling and added checks in various parts of the code, uncovering and fixing additional bugs.

---

### New Feature: LOD System

- Implemented a GPU-based LOD system for particle spheres.
- Spheres now use higher detail when closer to the camera and gradually switch to lower-detail versions (with the lowest being simple cubes) as they move farther away.
- The change is visually subtle, but significantly improves performance by reducing geometry complexity where it's least noticeable.
- All LOD geometry (icosphere variants) is precomputed at startup.

#### How It Works

- A compute shader classifies particles into LOD levels based on the projected screen-space size (in pixels) of each sphere.
- The algorithm is linear in time (O(N)) and adds minimal overhead to the total frame time.
- Basic frustum culling is also performed in the compute shader, skipping rendering for:
  - Particles behind the camera.
  - Particles outside the view frustum (i.e., outside the projection bounds).
- Culling is computed efficiently using the view and projection matrices.

These are 1 million spheres being rendered at 60 FPS in my GPU-less laptop:

![shot_1](https://github.com/user-attachments/assets/06d44bb9-d0cf-4bdc-bad9-aabd978da422)
![shot_0](https://github.com/user-attachments/assets/a755c489-86f3-4822-9853-2348770af745)

