### PR TITLE
add parameter to change color of box

### DIFF
--- a/src/RBox.cpp
+++ b/src/RBox.cpp
@@ -3,7 +3,7 @@
 #include"shaders.h"
 
 namespace superpunto{
-  RBox::RBox(float gscale, glm::mat4 *MVP, glm::vec3 size):
+  RBox::RBox(float gscale, glm::mat4 *MVP, glm::vec3 size, glm::vec3 color):
     gscale(gscale),
     MVP(MVP),
     size(size)
@@ -22,11 +22,17 @@ namespace superpunto{
 
     pr.use();
     glUniform1f(glGetUniformLocation(pr.id(), "gscale"), this->gscale);
-    glUniform3f(glGetUniformLocation(pr.id(), "color"), 0,0,1);
+    glUniform3f(glGetUniformLocation(pr.id(), "color"), color.x, color.y, color.z);
     pr.unbind();
 
 
   };
+
+  void RBox::setColor(glm::vec3 color){
+    pr.use();
+    glUniform3f(glGetUniformLocation(pr.id(), "color"), color.x, color.y, color.z);
+    pr.unbind();
+  }
 
   void RBox::setSize(glm::vec3 L){
 

--- a/src/RBox.h
+++ b/src/RBox.h
@@ -8,8 +8,9 @@
 namespace superpunto{
   class RBox{
   public:
-    RBox(float gscale, glm::mat4 *MVP, glm::vec3 size=glm::vec3(0,0,0));
+    RBox(float gscale, glm::mat4 *MVP, glm::vec3 size=glm::vec3(0,0,0), glm::vec3 color=glm::vec3(0,0,1));
     void setSize(glm::vec3 L);
+    void setColor(glm::vec3 color);
     void draw();
 
   private:

--- a/src/RRenderer.cpp
+++ b/src/RRenderer.cpp
@@ -9,6 +9,7 @@ RRenderer::RRenderer(std::shared_ptr<System> sys, std::shared_ptr<RWindow> in_w,
   picked[0] = picked[1] = -1;
   auto op = sys->getInputOptions();
   textRenderer.setFont(op.fontName.c_str(), int(op.target_FH / 10));
+  box.setColor(glm::vec3(op.box_color[0], op.box_color[1], op.box_color[2]));
   auto resolution = w->getResolution();
   proj =
       glm::perspective(op.fov, resolution.x / (float)resolution.y, znear, zfar);

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -32,6 +32,11 @@ void System::parseArguments() {
       options.bcolor[1] = std::stod(m_argv[i + 2]);
       options.bcolor[2] = std::stod(m_argv[i + 3]);
     }
+    if (strcmp(m_argv[i], "--boxcolor") == 0) {
+      options.box_color[0] = std::stod(m_argv[i+1]);
+      options.box_color[1] = std::stod(m_argv[i+2]);
+      options.box_color[2] = std::stod(m_argv[i+3]);
+    }
     if (strcmp(m_argv[i], "--resolution") == 0) {
       options.target_FW = std::atoi(m_argv[i + 1]);
       options.target_FH = std::atoi(m_argv[i + 2]);
@@ -80,6 +85,8 @@ void System::printHelp() {
                        "integers) (0xFF=red=255). Overrides palette");
   // log<System::MESSAGE>("\t  --renderer [render=arrows,particles]: Rendering
   // mode.");
+  log<System::MESSAGE>(
+      "\t  --boxcolor R G B : Color of the bounding box in RGB, default is 0 0 1");
   log<System::MESSAGE>("\t  --nobox : Do not render the bounding box.");
   log<System::MESSAGE>("\t  --noaxis : Do not render axis labels.");
   // log<System::MESSAGE>("\t  --binary : Read the file in binary SuperIO

--- a/src/System.h
+++ b/src/System.h
@@ -21,7 +21,8 @@ namespace superpunto{
   struct Options{
     bool record_movie = false;
     int frames_between_screenshots = 2;
-    float bcolor[3] = {0,0,0};
+    float bcolor[3] = {0,0,0}; // background color
+    float box_color[3] = {0,0,1};
     std::string fontName = xSPUNTOSTR(USEFONT);
     std::string readFile = std::string("/dev/stdin");
     RenderType render_type = RenderType::PARTICLES;


### PR DESCRIPTION
I'm planning to use superpunto for a few insets in a paper and the dark blue of the periodic box wasn't showing up well. This adds the functionality to change the box color in the same style as the background.

I added the feature the same way the box size seemed to be handled, but it felt a bit clunky. Let me know if you see a better way to add it or if there's anything deeper in spunto that I need to update as well.