### PR TITLE
Fix box size

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ If some of the columns are missing, this is the behavior according to the number
 	3: XYZ ->r=1, c=0
 	4: XYZC -> r=1
 
+The simulation box is centered at (0,0,0) and goes from (-Lx/2, -Ly/2, -Lz/2) to (Lx/2, Ly/2, Lz/2).
+
 ### About colors
 
 The column color can be treated in two ways:

--- a/src/RBox.cpp
+++ b/src/RBox.cpp
@@ -32,7 +32,7 @@ namespace superpunto{
 
     this->size = L;
     pr.use();
-    glUniform3f(glGetUniformLocation(pr.id(), "boxSize"), 2*size.x, 2*size.y, 2*size.z);
+    glUniform3f(glGetUniformLocation(pr.id(), "boxSize"), size.x, size.y, size.z);
     pr.unbind();
   }
 


### PR DESCRIPTION
Input files for spunto consistently require me to input half the box size I actually want (i.e. use Lx=5 in the input file when I actually want Lx=10). It seemed like a bug to me and changing this line fixes the issue.

It's also possible I missed something if it has to do with the box being centered at the origin instead of centered at (Lx/2, Ly/2, Lz/2), but this created the visualizations that I wanted without a hitch.